### PR TITLE
Made card marks more visible.

### DIFF
--- a/src/components/Tally.tsx
+++ b/src/components/Tally.tsx
@@ -14,13 +14,7 @@ export default class Tally extends React.Component<IProps> {
     }
     return (
       <span style={{ fontFamily: "monospace" }}>
-        {ticks.map(() => (
-          <FaBug
-            key={Math.random()
-              .toString(36)
-              .substr(2, 5)}
-          />
-        ))}
+        {ticks.map((_, index) => <FaBug key={index} />)}
       </span>
     );
   }

--- a/src/components/Tally.tsx
+++ b/src/components/Tally.tsx
@@ -12,7 +12,9 @@ export default class Tally extends React.Component<IProps> {
       ticks.push(null);
     }
     return (
-      <span style={{ fontFamily: "monospace" }}>{ticks.map(() => "|")}</span>
+      <span style={{ fontFamily: "monospace" }}>
+        {ticks.map(() => "\u26AB")}
+      </span>
     );
   }
 }

--- a/src/components/Tally.tsx
+++ b/src/components/Tally.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { FaBug } from "react-icons/lib/fa";
 
 interface IProps {
   count: number;
@@ -13,7 +14,7 @@ export default class Tally extends React.Component<IProps> {
     }
     return (
       <span style={{ fontFamily: "monospace" }}>
-        {ticks.map(() => "\u26AB")}
+        {ticks.map(() => <FaBug key={"bug"} />)}
       </span>
     );
   }

--- a/src/components/Tally.tsx
+++ b/src/components/Tally.tsx
@@ -14,7 +14,13 @@ export default class Tally extends React.Component<IProps> {
     }
     return (
       <span style={{ fontFamily: "monospace" }}>
-        {ticks.map(() => <FaBug key={"bug"} />)}
+        {ticks.map(() => (
+          <FaBug
+            key={Math.random()
+              .toString(36)
+              .substr(2, 5)}
+          />
+        ))}
       </span>
     );
   }


### PR DESCRIPTION
Replaced tally with unicode dot:
<img width="413" alt="screen shot 2018-08-03 at 12 57 49 pm" src="https://user-images.githubusercontent.com/1214589/43663318-ebb70158-971d-11e8-9d9e-cbb1e1d07e75.png">

@osmose what do you think?
