### PR TITLE
Ignore coverage folder in linter options

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,8 @@
   "linterOptions": {
     "exclude": [
       "config/**/*.js",
-      "node_modules/**/*.ts"
+      "node_modules/**/*.ts",
+      "coverage/lcov-report/*.js"
     ]
   },
   "rules": {


### PR DESCRIPTION
If coverage is not ignored running `yarn test --coverage` breaks the project locally.